### PR TITLE
DBモデリング1の課題2

### DIFF
--- a/I84PdeRyF2ApGF/db_modeling01/task_02/db_modeling02.pu
+++ b/I84PdeRyF2ApGF/db_modeling01/task_02/db_modeling02.pu
@@ -88,7 +88,6 @@
         id [PK] : INT : 商品ID
         --
         name : VARCHAR : 商品名称
-        category_id [FK] : INT : カテゴリーID
         price : INT : 値段
         tax_rate_id [FK] : 消費税ID
     }
@@ -100,10 +99,17 @@
         sushi_id [FK] : INT : 寿司ID
     }
 
-    Entity "categories\nカテゴリー" as c {
+    Entity "categories\nカテゴリーマスタ" as c {
         id [PK] : INT : カテゴリーID
         --
         name : VARCHAR : カテゴリー名称
+    }
+
+    Entity "product_categories\n商品カテゴリー" as pc {
+        id [PK] : INT : 商品カテゴリーID
+        --
+        product_id [FK] : INT : 商品ID
+        category_id [FK] : INT : カテゴリーID
     }
 
     orders }o..r..|| customers
@@ -111,7 +117,8 @@
     orders }o-l-|| tax_rate
     order_details }o--|| p
     tax_rate ||--o{ p
-    p ||-l-o{ c
+    p ||..o{ pc
+    pc }o..|| c
     p ||..o{ s_d
     order_details ||..o{ options
     options }o..|| om

--- a/I84PdeRyF2ApGF/db_modeling01/task_02/db_modeling02.pu
+++ b/I84PdeRyF2ApGF/db_modeling01/task_02/db_modeling02.pu
@@ -59,9 +59,9 @@
 
     Entity "order_options\n注文オプション" as options {
         id [PK] : INT : 注文オプションID
-        order_id [PK, FK] : INT : 注文ID
-        order_detail_id [PK, FK] : INT : 注文明細ID
         --
+        order_id [FK] : INT : 注文ID
+        order_detail_id [FK] : INT : 注文明細ID
         option_id [FK] : INT : オプションID
     }
 

--- a/I84PdeRyF2ApGF/db_modeling01/task_02/db_modeling02.pu
+++ b/I84PdeRyF2ApGF/db_modeling01/task_02/db_modeling02.pu
@@ -1,45 +1,45 @@
 @startuml dbModeling1
-    Entity "menues(メニュー)" as menues {
-        id [PK] : INT : メニューID
-        item_id [PK, FK] : INT : 商品ID(寿司ID or セットID)
-        --
-        price : INT : 値段
-        tax_rate_id [FK] : INT : 消費税ID
-    }
+    ' Entity "menues\nメニュー" as menues {
+    '     id [PK] : INT : メニューID
+    '     item_id [PK, FK] : INT : 商品ID(寿司ID or セットID)
+    '     --
+    '     price : INT : 値段
+    '     tax_rate_id [FK] : INT : 消費税ID
+    ' }
 
-    Entity "sushi_menues(寿司メニュー)" as sushi_menues {
-        id [PK] : INT : 寿司ID
-        --
-        name : VARCHAR : 寿司名称
-    }
+    ' Entity "sushi_menues\n寿司メニュー" as sushi_menues {
+    '     id [PK] : INT : 寿司ID
+    '     --
+    '     name : VARCHAR : 寿司名称
+    ' }
 
-    Entity "set_menues(セットメニュー)" as set_menues {
-        id [PK] : INT : セットID
-        --
-        name : VARCHAR : セット名称
-        set_detail_id [FK] : INT : セット詳細ID
-    }
+    ' Entity "set_menues\nセットメニュー" as set_menues {
+    '     id [PK] : INT : セットID
+    '     --
+    '     name : VARCHAR : セット名称
+    '     set_detail_id [FK] : INT : セット詳細ID
+    ' }
 
-    Entity "set_details(セットメニュー詳細)" as set_details {
-        id [PK] : INT : セット詳細ID
-        sushi_menu_id [PK, FK] : INT : 寿司ID
-    }
+    ' Entity "set_details\nセットメニュー詳細" as set_details {
+    '     id [PK] : INT : セット詳細ID
+    '     sushi_menu_id [PK, FK] : INT : 寿司ID
+    ' }
 
-    Entity "tax_rate(消費税率マスタ)" as tax_rate{
+    Entity "tax_rate\n消費税率マスタ" as tax_rate{
         id [PK] : INT : 消費税区分ID
         --
         tax_rate : DECIMAL : 消費税率
         start_date : DATETIME : 適用開始日
     }
 
-    Entity "customers(顧客)" as customers {
+    Entity "customers\n顧客" as customers {
         id [PK] : INT : 顧客ID
         --
         name : VARCHAR : 顧客名
         phone_number : VARCHAR : 電話番号
     }
 
-    Entity "orders(注文票)" as orders {
+    Entity "orders\n注文票" as orders {
         id [PK] : INT : 注文ID
         --
         customer_id [FK] : INT : 顧客ID
@@ -48,48 +48,84 @@
         payment_date : DATETIME : 支払日
     }
 
-    Entity "order_details(注文明細)" as order_details {
+    Entity "order_details\n注文明細" as order_details {
         order_id [PK, FK] : INT : 注文ID 
         order_detail_id [PK] : INT : 注文明細番号 
         --
-        menu_id [FK] : INT : メニューID
+        product_id [FK] : INT : 商品ID
         quantity : INT : 個数
+        ' option_id [FK] : INT : オプションID
+    }
+
+    Entity "order_options\n注文オプション" as options {
+        id [PK] : INT : 注文オプションID
+        order_id [PK, FK] : INT : 注文ID
+        order_detail_id [PK, FK] : INT : 注文明細ID
+        --
         option_id [FK] : INT : オプションID
     }
 
-    Entity "order_options(オプション)" as options {
+    Entity "options\nオプションマスタ" as om{
         id [PK] : INT : オプションID
         --
-        condiment_detail_id [FK] : INT : 薬味詳細ID
-        rice_option_id [FK] : INT : シャリID
+        name : VARCHAR : オプション名称
     }
 
-    Entity "condiments(薬味)" as condiments{
-        id [PK] : INT : 薬味ID
+    ' Entity "condiments\n薬味" as condiments{
+    '     id [PK] : INT : 薬味ID
+    '     --
+    '     condiment_detail_id : INT : 薬味詳細ID
+    '     name : VARCHAR : 薬味名称
+    ' }
+
+    ' Entity "rice_option\nシャリ" as rice{
+    '     id [PK] : INT : シャリID
+    '     --
+    '     size : VARCHAR : サイズ
+    ' }
+
+    Entity "products\n商品" as p{
+        id [PK] : INT : 商品ID
         --
-        condiment_detail_id : INT : 薬味詳細ID
-        name : VARCHAR : 薬味名称
+        name : VARCHAR : 商品名称
+        category_id [FK] : INT : カテゴリーID
+        price : INT : 値段
+        tax_rate_id [FK] : 消費税ID
     }
 
-    Entity "rice_option(シャリ)" as rice{
-        id [PK] : INT : シャリID
+    Entity "set_details\nセット詳細" as s_d{
+        id [PK] : INT : セット詳細ID
         --
-        size : VARCHAR : サイズ
+        set_id [FK] : INT : 商品ID
+        sushi_id [FK] : INT : 寿司ID
     }
 
-    orders }o-r-|| customers
+    Entity "categories\nカテゴリー" as c {
+        id [PK] : INT : カテゴリーID
+        --
+        name : VARCHAR : カテゴリー名称
+    }
+
+    orders }o..r..|| customers
     orders ||-d-|{ order_details
     orders }o-l-|| tax_rate
-    order_details  ||--|| menues
-    menues ||--o| sushi_menues
-    menues ||--o| set_menues
-    set_menues ||--o{ set_details
-    set_details ||--|| sushi_menues
-    tax_rate ||--|| menues
-    order_details ||-r-o| options
-    options |o--o{ condiments
-    options |o--o| rice
+    order_details }o--|| p
+    tax_rate ||--o{ p
+    p ||-l-o{ c
+    p ||..o{ s_d
+    order_details ||..o{ options
+    options }o..|| om
+    ' order_details  ||--|| menues
+    ' menues ||--o| sushi_menues
+    ' menues ||--o| set_menues
+    ' set_menues ||--o{ set_details
+    ' set_details ||--|| sushi_menues
+    ' tax_rate ||--|| menues
+    ' order_details ||-r-o| options
+    ' options |o--o{ condiments
+    ' options |o--o| rice
 
+    
     ' * 主キー
     ' + 外部キー
     ' カラム名 : 型 : 説明

--- a/I84PdeRyF2ApGF/db_modeling01/task_02/db_modeling02.pu
+++ b/I84PdeRyF2ApGF/db_modeling01/task_02/db_modeling02.pu
@@ -1,0 +1,106 @@
+@startuml dbModeling1
+    Entity "menues(メニュー)" as menues {
+        id [PK] : INT : メニューID
+        item_id [PK, FK] : INT : 商品ID(寿司ID or セットID)
+        --
+        price : INT : 値段
+        tax_rate_id [FK] : INT : 消費税ID
+    }
+
+    Entity "sushi_menues(寿司メニュー)" as sushi_menues {
+        id [PK] : INT : 寿司ID
+        --
+        name : VARCHAR : 寿司名称
+    }
+
+    Entity "set_menues(セットメニュー)" as set_menues {
+        id [PK] : INT : セットID
+        --
+        name : VARCHAR : セット名称
+        set_detail_id [FK] : INT : セット詳細ID
+    }
+
+    Entity "set_details(セットメニュー詳細)" as set_details {
+        id [PK] : INT : セット詳細ID
+        sushi_menu_id [PK, FK] : INT : 寿司ID
+    }
+
+    Entity "tax_rate(消費税率マスタ)" as tax_rate{
+        id [PK] : INT : 消費税区分ID
+        --
+        tax_rate : DECIMAL : 消費税率
+        start_date : DATETIME : 適用開始日
+    }
+
+    Entity "customers(顧客)" as customers {
+        id [PK] : INT : 顧客ID
+        --
+        name : VARCHAR : 顧客名
+        phone_number : VARCHAR : 電話番号
+    }
+
+    Entity "orders(注文票)" as orders {
+        id [PK] : INT : 注文ID
+        --
+        customer_id [FK] : INT : 顧客ID
+        tax_rate_id [FK] : INT : 消費税区分ID 
+        order_date : DATETIME : 注文日
+        payment_date : DATETIME : 支払日
+    }
+
+    Entity "order_details(注文明細)" as order_details {
+        order_id [PK, FK] : INT : 注文ID 
+        order_detail_id [PK] : INT : 注文明細番号 
+        --
+        menu_id [FK] : INT : メニューID
+        quantity : INT : 個数
+        option_id [FK] : INT : オプションID
+    }
+
+    Entity "order_options(オプション)" as options {
+        id [PK] : INT : オプションID
+        --
+        condiment_detail_id [FK] : INT : 薬味詳細ID
+        rice_option_id [FK] : INT : シャリID
+    }
+
+    Entity "condiments(薬味)" as condiments{
+        id [PK] : INT : 薬味ID
+        --
+        condiment_detail_id : INT : 薬味詳細ID
+        name : VARCHAR : 薬味名称
+    }
+
+    Entity "rice_option(シャリ)" as rice{
+        id [PK] : INT : シャリID
+        --
+        size : VARCHAR : サイズ
+    }
+
+    orders }o-r-|| customers
+    orders ||-d-|{ order_details
+    orders }o-l-|| tax_rate
+    order_details  ||--|| menues
+    menues ||--o| sushi_menues
+    menues ||--o| set_menues
+    set_menues ||--o{ set_details
+    set_details ||--|| sushi_menues
+    tax_rate ||--|| menues
+    order_details ||-r-o| options
+    options |o--o{ condiments
+    options |o--o| rice
+
+    ' * 主キー
+    ' + 外部キー
+    ' カラム名 : 型 : 説明
+
+    ' 1対０また1
+    ' A ||--o| B
+    ' 1対1
+    ' A ||--|| B
+    ' 1対0以上
+    ' A ||--o{ B
+    ' 1対1以上
+    ' A ||--|{ B
+
+@enduml


### PR DESCRIPTION
## やったこと
DBモデリング1の課題2
https://airtable.com/appEMvY3FsesCpF8G/tbl4FviBLqTJHLjP4/viwvs2HU05ufvqKUD/recaGGRzj3p38rdMX?blocks=hide
  
## ER図
![image](https://user-images.githubusercontent.com/85465075/224074929-41b1a503-bfcc-46e4-badd-c31703ecdeb3.png)

  
### シャリ大小の選択仕様の追加
order_optionsテーブルを作成し、ひとつの注文明細に対して、薬味やシャリのサイズを選択できるようにした。
シャリのサイズに関しては、シャリに関するオプションをまとめられるようにテーブルを作成し、大小以外のオプションが追加された場合でも対応できるようにした。
その他のオプションが思いつかないため、order_optionsテーブルにシャリのサイズカラムを作ってもいいかなとも思いました（テーブルが増えすぎても管理やデータの抽出が複雑になってしまうかと思ったため…🤔）

### 今月の人気の寿司ネタを特定する(セット商品の売り上げとは別で)
当初の設計から考慮していたこともあり、大きな変更点はなし。
注文明細に対して、単品の寿司なのか、セットメニューかをitem_idで判別し、セットメニューの場合は、どの寿司がセットになっているのかをセットメニュー詳細テーブルで寿司IDを格納することで管理するしている。