### PR TITLE
hirakata/DBモデリング1の課題3

### DIFF
--- a/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
+++ b/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
@@ -101,6 +101,7 @@
         --
         products_id [FK] : INT : 商品ID
         name : VARCHAR : 商品名称
+        price : INT : 値段
         tax_rate_id [FK] : 消費税ID
         sales_status : INT : 販売状況
         insert_date : DATETIME : 登録日

--- a/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
+++ b/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
@@ -58,7 +58,7 @@
         destination : VARCHAR : 配達先
         payment_method : INT : 決済方法
         ordered_at : DATETIME : 注文日時
-        payment_at : DATETIME : 支払日時
+        payed_at : DATETIME : 支払日時
     }
 
     Entity "order_products\n注文商品" as order_details {

--- a/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
+++ b/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
@@ -19,7 +19,9 @@
         id [PK] : INT : 住所ID
         --
         customer_id [FK] : INT : 顧客ID
-        address : VARCHAR : 住所 
+        postal_code : VARCHAR : 郵便番号
+        address1 : VARCHAR : 住所1
+        address2 : VARCHAR : 住所2
     }
     
     Entity "registerd_customers\n登録顧客" as r_c{
@@ -54,8 +56,12 @@
         customer_id [FK] : INT : 顧客ID
         tax_rate_id [FK] : INT : 消費税ID
         used_coupon_id [FK] : INT : 使用クーポンID
+        subtotal_price : INT : 小計金額
+        total_price : INT : 合計金額
         order_method : INT : 注文方法
-        destination : VARCHAR : 配達先
+        postal_code : VARCHAR : 配達先郵便番号
+        address1 : VARCHAR : 住所1
+        address2 : VARCHAR : 住所2
         payment_method : INT : 決済方法
         ordered_at : DATETIME : 注文日時
         payed_at : DATETIME : 支払日時

--- a/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
+++ b/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
@@ -1,0 +1,108 @@
+@startuml dbModeling1
+    Entity "tax_rate\n消費税率マスタ" as tax_rate{
+        id [PK] : INT : 消費税区分ID
+        --
+        tax_rate : DECIMAL : 消費税率
+        start_date : DATETIME : 適用開始日
+    }
+
+    Entity "customers\n顧客" as customers {
+        id [PK] : INT : 顧客ID
+        --
+        name : VARCHAR : 顧客名
+        phone_number : VARCHAR : 電話番号
+    }
+
+    Entity "orders\n注文票" as orders {
+        id [PK] : INT : 注文ID
+        --
+        customer_id [FK] : INT : 顧客ID
+        tax_rate_id [FK] : INT : 消費税区分ID 
+        order_date : DATETIME : 注文日
+        payment_date : DATETIME : 支払日
+    }
+
+    Entity "order_details\n注文明細" as order_details {
+        order_id [PK, FK] : INT : 注文ID 
+        order_detail_id [PK] : INT : 注文明細番号 
+        --
+        product_id [FK] : INT : 販売商品ID
+        quantity : INT : 個数
+    }
+
+    Entity "order_options\n注文オプション" as options {
+        id [PK] : INT : 注文オプションID
+        --
+        order_id [FK] : INT : 注文ID
+        order_detail_id [FK] : INT : 注文明細ID
+        option_id [FK] : INT : オプションID
+    }
+
+    Entity "options\nオプションマスタ" as om{
+        id [PK] : INT : オプションID
+        --
+        name : VARCHAR : オプション名称
+    }
+
+    Entity "sales_product\n販売商品" as s_p{
+        id [PK] : INT : 販売商品ID
+        --
+        product_id [FK] : INT : 商品ID
+        price : INT : 値段
+        tax_rate_id [FK] : 消費税ID
+        sales_status : INT : 販売状況
+        update_date : DATETIME : 更新日
+    }
+
+    Entity "products\n商品マスタ" as p{
+        id [PK] : INT : 商品ID
+        --
+        name : VARCHAR : 商品名称
+    }
+
+    Entity "set_details\nセット詳細" as s_d{
+        id [PK] : INT : セット詳細ID
+        --
+        set_id [FK] : INT : 商品ID
+        sushi_id [FK] : INT : 寿司ID
+    }
+
+    Entity "categories\nカテゴリーマスタ" as c {
+        id [PK] : INT : カテゴリーID
+        --
+        name : VARCHAR : カテゴリー名称
+    }
+
+    Entity "product_categories\n商品カテゴリー" as pc {
+        id [PK] : INT : 商品カテゴリーID
+        --
+        product_id [FK] : INT : 商品ID
+        category_id [FK] : INT : カテゴリーID
+    }
+
+    orders }o..r..|| customers
+    orders ||-d-|{ order_details
+    orders }o-l-|| tax_rate
+    order_details }o--|| s_p
+    tax_rate ||--o{ s_p
+    s_p ||..o{ pc
+    pc }o..|| c
+    s_p ||..o{ s_d
+    order_details ||..o{ options
+    options }o..|| om
+    p ||..r..o{ s_p
+    
+    ' * 主キー
+    ' + 外部キー
+    ' カラム名 : 型 : 説明
+
+    ' 1対０また1
+    ' A ||--o| B
+    ' 1対1
+    ' A ||--|| B
+    ' 1対0以上
+    ' A ||--o{ B
+    ' 1対1以上
+    ' A ||--|{ B
+
+@enduml

--- a/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
+++ b/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
@@ -46,6 +46,7 @@
         --
         customer_id [FK] : INT : 顧客ID
         tax_rate_id [FK] : INT : 消費税ID
+        used_coupon_id [FK] : INT : 使用クーポンID
         order_method : INT : 注文方法
         payment_method : INT : 決済方法
         order_date : DATETIME : 注文日
@@ -83,7 +84,7 @@
         name : VARCHAR : 梱包名称
         price : INT : 梱包代
     }
-    
+
     Entity "products\n商品マスタ" as s_p{
         id [PK] : INT : 商品ID
         --
@@ -144,6 +145,7 @@
     r_c ||..o{ c_h_c
     c_h_c }o..|| f_c
     c_m ||..o{ c_h_c
+    c_m |o..o{orders
 
     ' * 主キー
     ' + 外部キー

--- a/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
+++ b/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
@@ -12,7 +12,6 @@
         name : VARCHAR : 名前
         phone_number : VARCHAR : 電話番号
         email : VARCHAR : メールアドレス
-        address : VARCHAR : 住所
     }
 
     Entity "customer_addresses\n顧客住所" as c_a{

--- a/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
+++ b/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
@@ -3,11 +3,11 @@
         id [PK] : INT : 消費税区分ID
         --
         tax_rate : DECIMAL : 消費税率
-        start_date : DATETIME : 適用開始日
+        start_on : DATE : 適用開始日
     }
 
-    Entity "free_customers\nフリー客" as f_c {
-        id [PK] : INT : フリー客ID
+    Entity "guest_customers\nゲスト客" as f_c {
+        id [PK] : INT : ゲストID
         --
         name : VARCHAR : 名前
         phone_number : VARCHAR : 電話番号
@@ -15,13 +15,20 @@
         address : VARCHAR : 住所
     }
 
+    Entity "customer_addresses\n顧客住所" as c_a{
+        id [PK] : INT : 住所ID
+        --
+        customer_id [FK] : INT : 顧客ID
+        address : VARCHAR : 住所 
+    }
+    
     Entity "registerd_customers\n登録顧客" as r_c{
         id [PK] : INT : 登録顧客ID
         --
         name : VARCHAR : 名前
         phone_number : VARCHAR : 電話番号
         email : VARCHAR : メールアドレス
-        address : VARCHAR : 住所
+        customer_address_id : VARCHAR : 顧客住所ID
     }
 
     Entity "customer_holding_coupons\n顧客保有クーポン" as c_h_c{
@@ -29,16 +36,16 @@
         --
         customer_id [FK] : INT : 顧客ID
         coupon_id [FK] : INT : クーポンID
-        used : BOOLEAN : 使用有無
+        used_at : DATETIME : 使用日時
     }
 
     Entity "coupons\nクーポンマスタ" as c_m{
         id [PK] : INT : クーポンID
         --
         name : VARCHAR : クーポン名称
-        discount : INT : 割引額
-        start_date : DATETIME : 適用開始日
-        end_date : DATETIME : 適用終了日
+        discount_price : INT : 割引額
+        start_at : DATETIME : 適用開始日
+        end_at : DATETIME : 適用終了日
     }
 
     Entity "orders\n注文票" as orders {
@@ -48,12 +55,13 @@
         tax_rate_id [FK] : INT : 消費税ID
         used_coupon_id [FK] : INT : 使用クーポンID
         order_method : INT : 注文方法
+        destination : VARCHAR : 配達先
         payment_method : INT : 決済方法
-        order_date : DATETIME : 注文日
-        payment_date : DATETIME : 支払日
+        order_at : DATETIME : 注文日時
+        payment_at : DATETIME : 支払日時
     }
 
-    Entity "order_details\n注文明細" as order_details {
+    Entity "order_products\n注文商品" as order_details {
         order_id [PK, FK] : INT : 注文ID 
         order_detail_id [PK] : INT : 注文明細番号 
         --
@@ -92,20 +100,20 @@
         price : INT : 値段
         tax_rate_id [FK] : 消費税ID
         sales_status : INT : 販売状況
-        insert_date : DATETIME : 登録日
-        update_date : DATETIME : 更新日
+        insert_at : DATETIME : 登録日時
+        update_at : DATETIME : 更新日時
     }
 
-    Entity "products_history\n商品履歴" as p_h {
-        id [PK] : INT : 商品履歴ID
+    Entity "products_update_histories\n商品変更履歴" as p_h {
+        id [PK] : INT : 商品変更履歴ID
         --
         products_id [FK] : INT : 商品ID
         name : VARCHAR : 商品名称
         price : INT : 値段
         tax_rate_id [FK] : 消費税ID
         sales_status : INT : 販売状況
-        insert_date : DATETIME : 登録日
-        update_date : DATETIME : 更新日
+        product_insert_at : DATETIME : 商品登録日時
+        product_update_at : DATETIME : 商品更新日時
     }
 
     Entity "set_details\nセット詳細" as s_d{
@@ -147,6 +155,8 @@
     c_h_c }o..|| f_c
     c_m ||..o{ c_h_c
     c_m |o..o{orders
+    c_a }|.r.|| r_c
+
 
     ' * 主キー
     ' + 外部キー

--- a/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
+++ b/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
@@ -3,7 +3,7 @@
         id [PK] : INT : 消費税区分ID
         --
         tax_rate : DECIMAL : 消費税率
-        start_on : DATE : 適用開始日
+        starts_at : DATE : 適用開始日
     }
 
     Entity "guest_customers\nゲスト客" as f_c {
@@ -44,8 +44,8 @@
         --
         name : VARCHAR : クーポン名称
         discount_price : INT : 割引額
-        start_at : DATETIME : 適用開始日
-        end_at : DATETIME : 適用終了日
+        starts_at : DATETIME : 適用開始日
+        ends_at : DATETIME : 適用終了日
     }
 
     Entity "orders\n注文票" as orders {
@@ -57,7 +57,7 @@
         order_method : INT : 注文方法
         destination : VARCHAR : 配達先
         payment_method : INT : 決済方法
-        order_at : DATETIME : 注文日時
+        ordered_at : DATETIME : 注文日時
         payment_at : DATETIME : 支払日時
     }
 
@@ -100,8 +100,8 @@
         price : INT : 値段
         tax_rate_id [FK] : 消費税ID
         sales_status : INT : 販売状況
-        insert_at : DATETIME : 登録日時
-        update_at : DATETIME : 更新日時
+        inserted_at : DATETIME : 登録日時
+        updated_at : DATETIME : 更新日時
     }
 
     Entity "products_update_histories\n商品変更履歴" as p_h {
@@ -112,8 +112,8 @@
         price : INT : 値段
         tax_rate_id [FK] : 消費税ID
         sales_status : INT : 販売状況
-        product_insert_at : DATETIME : 商品登録日時
-        product_update_at : DATETIME : 商品更新日時
+        product_inserted_at : DATETIME : 商品登録日時
+        product_updated_at : DATETIME : 商品更新日時
     }
 
     Entity "set_details\nセット詳細" as s_d{

--- a/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
+++ b/I84PdeRyF2ApGF/db_modeling01/task_03/db_modeling03.pu
@@ -6,18 +6,48 @@
         start_date : DATETIME : 適用開始日
     }
 
-    Entity "customers\n顧客" as customers {
-        id [PK] : INT : 顧客ID
+    Entity "free_customers\nフリー客" as f_c {
+        id [PK] : INT : フリー客ID
         --
-        name : VARCHAR : 顧客名
+        name : VARCHAR : 名前
         phone_number : VARCHAR : 電話番号
+        email : VARCHAR : メールアドレス
+        address : VARCHAR : 住所
+    }
+
+    Entity "registerd_customers\n登録顧客" as r_c{
+        id [PK] : INT : 登録顧客ID
+        --
+        name : VARCHAR : 名前
+        phone_number : VARCHAR : 電話番号
+        email : VARCHAR : メールアドレス
+        address : VARCHAR : 住所
+    }
+
+    Entity "customer_holding_coupons\n顧客保有クーポン" as c_h_c{
+        id [PK] : INT :  ID
+        --
+        customer_id [FK] : INT : 顧客ID
+        coupon_id [FK] : INT : クーポンID
+        used : BOOLEAN : 使用有無
+    }
+
+    Entity "coupons\nクーポンマスタ" as c_m{
+        id [PK] : INT : クーポンID
+        --
+        name : VARCHAR : クーポン名称
+        discount : INT : 割引額
+        start_date : DATETIME : 適用開始日
+        end_date : DATETIME : 適用終了日
     }
 
     Entity "orders\n注文票" as orders {
         id [PK] : INT : 注文ID
         --
         customer_id [FK] : INT : 顧客ID
-        tax_rate_id [FK] : INT : 消費税区分ID 
+        tax_rate_id [FK] : INT : 消費税ID
+        order_method : INT : 注文方法
+        payment_method : INT : 決済方法
         order_date : DATETIME : 注文日
         payment_date : DATETIME : 支払日
     }
@@ -27,6 +57,9 @@
         order_detail_id [PK] : INT : 注文明細番号 
         --
         product_id [FK] : INT : 販売商品ID
+        product_price : INT : 商品価格
+        package_id : INT : 梱包ID 
+        option_price : INT : 梱包価格
         quantity : INT : 個数
     }
 
@@ -44,20 +77,33 @@
         name : VARCHAR : オプション名称
     }
 
-    Entity "sales_product\n販売商品" as s_p{
-        id [PK] : INT : 販売商品ID
+    Entity "packages\n梱包マスタ" as p_o{
+        id [PK] : INT : 梱包ID
         --
-        product_id [FK] : INT : 商品ID
-        price : INT : 値段
-        tax_rate_id [FK] : 消費税ID
-        sales_status : INT : 販売状況
-        update_date : DATETIME : 更新日
+        name : VARCHAR : 梱包名称
+        price : INT : 梱包代
     }
-
-    Entity "products\n商品マスタ" as p{
+    
+    Entity "products\n商品マスタ" as s_p{
         id [PK] : INT : 商品ID
         --
         name : VARCHAR : 商品名称
+        price : INT : 値段
+        tax_rate_id [FK] : 消費税ID
+        sales_status : INT : 販売状況
+        insert_date : DATETIME : 登録日
+        update_date : DATETIME : 更新日
+    }
+
+    Entity "products_history\n商品履歴" as p_h {
+        id [PK] : INT : 商品履歴ID
+        --
+        products_id [FK] : INT : 商品ID
+        name : VARCHAR : 商品名称
+        tax_rate_id [FK] : 消費税ID
+        sales_status : INT : 販売状況
+        insert_date : DATETIME : 登録日
+        update_date : DATETIME : 更新日
     }
 
     Entity "set_details\nセット詳細" as s_d{
@@ -80,18 +126,25 @@
         category_id [FK] : INT : カテゴリーID
     }
 
-    orders }o..r..|| customers
+    orders }o..r..|| f_c
+    r_c ||....o{ orders
     orders ||-d-|{ order_details
     orders }o-l-|| tax_rate
     order_details }o--|| s_p
     tax_rate ||--o{ s_p
+    tax_rate ||--o{ p_h
     s_p ||..o{ pc
     pc }o..|| c
     s_p ||..o{ s_d
     order_details ||..o{ options
     options }o..|| om
-    p ||..r..o{ s_p
-    
+    s_p ||..l..o{ p_h 
+    order_details }o..|| p_o
+    ' p_o ||..o{ p_o_h
+    r_c ||..o{ c_h_c
+    c_h_c }o..|| f_c
+    c_m ||..o{ c_h_c
+
     ' * 主キー
     ' + 外部キー
     ' カラム名 : 型 : 説明


### PR DESCRIPTION
## やったこと
DBモデリング1の課題3
https://airtable.com/appEMvY3FsesCpF8G/tbl4FviBLqTJHLjP4/viwvs2HU05ufvqKUD/recaGGRzj3p38rdMX?blocks=hide
  
- ER図の修正
  
## ER図
![image](https://user-images.githubusercontent.com/85465075/226153330-b84c0e9c-39c4-482c-854d-2c8f2d605a03.png)

  
## 追加仕様に対する対応
### クーポン機能
クーポンマスタにクーポンの情報を格納。適用開始日と適用終了日を持たせることで、会員クーポンと共通クーポンを判別する。顧客テーブルを登録顧客テーブルとフリー客テーブルに分け、顧客保有クーポンという中間テーブルを使用することで各顧客の保有するクーポンの情報、使用の有無を管理する。
  
### サイドメニューの持ち帰り
商品カテゴリーテーブルで商品で寿司、サイドメニューなどのカテゴリーは分類できるため、特に修正はなし。
  
### 商品の販売状況（販売中、販売停止）管理
商品マスタの商品情報に販売状況カラムを追加。商品履歴テーブルも作成し、販売状況がいつ更新されたかの履歴や金額の改訂などがあった際の履歴を保持できるようにした。
    
### 梱包の選択
梱包情報（名称、梱包代）を格納するテーブルを作成し、注文明細と紐づくようにした。

### ECでの注文を想定
注文票テーブルに注文方法（ ECか店内持ち帰りか）と、決済方法（現金、カードなど）を格納するカラムを作成。ECで配達が必要になる場合や注文完了を通知する必要がある場合に備え、顧客のテーブルにメールアドレスと住所のカラムを追加。 

