### PR TITLE
hirakata/DBモデリング2

### DIFF
--- a/I84PdeRyF2ApGF/db_modeling02/.gitignore
+++ b/I84PdeRyF2ApGF/db_modeling02/.gitignore
@@ -1,0 +1,2 @@
+docker/
+/.env

--- a/I84PdeRyF2ApGF/db_modeling02/create_tables.sql
+++ b/I84PdeRyF2ApGF/db_modeling02/create_tables.sql
@@ -87,8 +87,10 @@ DROP TABLE IF EXISTS channel_messages CASCADE;
 
 CREATE TABLE channel_messages (
   id BIGINT UNSIGNED AUTO_INCREMENT,
+  post_channel_message_id BIGINT UNSIGNED NOT NULL UNIQUE,
   content VARCHAR(255) NOT NULL,
   PRIMARY KEY(id),
+  FOREIGN KEY (post_channel_message_id) REFERENCES post_channel_message (id) ON DELETE CASCADE,
   INDEX index_channel_messages_on_content (content)
 ) comment 'チャンネルメッセージ';
 
@@ -98,9 +100,11 @@ DROP TABLE IF EXISTS thread_messages CASCADE;
 CREATE TABLE thread_messages (
   id BIGINT UNSIGNED AUTO_INCREMENT,
   channel_message_id BIGINT UNSIGNED NOT NULL,
+  post_thread_message_id BIGINT UNSIGNED NOT NULL UNIQUE,
   content VARCHAR(255) NOT NULL,
   PRIMARY KEY(id),
   FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
+  FOREIGN KEY (post_thread_message_id) REFERENCES post_thread_message (id) ON DELETE CASCADE,
   INDEX index_thread_messages_on_content (content)
 ) comment 'スレッドメッセージ';
 
@@ -111,12 +115,10 @@ CREATE TABLE post_channel_message (
   id BIGINT UNSIGNED AUTO_INCREMENT,
   user_id BIGINT UNSIGNED,
   channel_id BIGINT UNSIGNED,
-  channel_message_id BIGINT UNSIGNED,
   posted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY(id, user_id, channel_id, channel_message_id),
+  PRIMARY KEY(id, user_id, channel_id),
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
   FOREIGN KEY (channel_id) REFERENCES channels(id) ON DELETE CASCADE,
-  FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
   INDEX index_post_channel_message_on_posted_at (posted_at)
 ) comment 'チャンネルメッセージ投稿';
 
@@ -151,11 +153,9 @@ DROP TABLE IF EXISTS post_thread_message CASCADE;
 CREATE TABLE post_thread_message (
   id BIGINT UNSIGNED AUTO_INCREMENT,
   user_id BIGINT UNSIGNED,
-  thread_message_id BIGINT UNSIGNED,
   posted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  PRIMARY KEY(id, user_id, thread_message_id),
+  PRIMARY KEY(id, user_id),
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-  FOREIGN KEY (thread_message_id) REFERENCES thread_messages(id) ON DELETE CASCADE,
   INDEX index_post_thread_message_on_posted_at (posted_at)
 ) comment 'スレッドメッセージ投稿';
 

--- a/I84PdeRyF2ApGF/db_modeling02/create_tables.sql
+++ b/I84PdeRyF2ApGF/db_modeling02/create_tables.sql
@@ -1,0 +1,185 @@
+-- ユーザー
+DROP TABLE IF EXISTS users CASCADE;
+
+CREATE TABLE users (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+	display_name VARCHAR(255) NOT NULL,
+	first_name VARCHAR(255) NOT NULL,
+	last_name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+	PRIMARY KEY(id)
+) comment 'ユーザー';
+
+-- ワークスペース
+DROP TABLE IF EXISTS workspaces CASCADE;
+
+CREATE TABLE workspaces (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+	name VARCHAR(255) NOT NULL,
+	PRIMARY KEY(id)
+) comment 'ワークスペース';
+
+-- チャンネル
+DROP TABLE IF EXISTS channels CASCADE;
+
+CREATE TABLE channels (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+    workspace_id BIGINT UNSIGNED NOT NULL ,
+	name VARCHAR(255) NOT NULL,
+	PRIMARY KEY(id),
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+) comment 'チャンネル';
+
+-- ワークスペース参加
+DROP TABLE IF EXISTS join_workspace CASCADE;
+
+CREATE TABLE join_workspace (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+    user_id BIGINT UNSIGNED NOT NULL,
+    workspace_id BIGINT UNSIGNED NOT NULL,
+	joined_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+	PRIMARY KEY(id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+) comment 'ワークスペース参加';
+
+-- ワークスペース脱退
+DROP TABLE IF EXISTS leave_workspace CASCADE;
+
+CREATE TABLE leave_workspace (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+    user_id BIGINT UNSIGNED NOT NULL,
+    workspace_id BIGINT UNSIGNED NOT NULL,
+	left_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+	PRIMARY KEY(id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+) comment 'ワークスペース脱退';
+
+-- チャンネル参加
+DROP TABLE IF EXISTS join_channel CASCADE;
+
+CREATE TABLE join_channel (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+    user_id BIGINT UNSIGNED NOT NULL,
+    channel_id BIGINT UNSIGNED NOT NULL,
+	joined_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+	PRIMARY KEY(id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (channel_id) REFERENCES channels(id) ON DELETE CASCADE
+) comment 'チャンネル参加';
+
+-- チャンネル脱退
+DROP TABLE IF EXISTS leave_channel CASCADE;
+
+CREATE TABLE leave_channel (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+    user_id BIGINT UNSIGNED NOT NULL,
+    channel_id BIGINT UNSIGNED NOT NULL,
+	left_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+	PRIMARY KEY(id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (channel_id) REFERENCES channels(id) ON DELETE CASCADE
+) comment 'チャンネル脱退';
+
+-- チャンネルメッセージ
+DROP TABLE IF EXISTS channel_messages CASCADE;
+
+CREATE TABLE channel_messages (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+    content VARCHAR(255) NOT NULL,
+	PRIMARY KEY(id),
+	INDEX index_channel_messages_on_content (content)
+) comment 'チャンネルメッセージ';
+
+-- スレッドメッセージ
+DROP TABLE IF EXISTS thread_messages CASCADE;
+
+CREATE TABLE thread_messages (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+    channel_message_id BIGINT UNSIGNED NOT NULL,
+    content VARCHAR(255) NOT NULL,
+	PRIMARY KEY(id),
+    FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
+	INDEX index_thread_messages_on_content (content)
+) comment 'スレッドメッセージ';
+
+-- チャンネルメッセージ投稿
+DROP TABLE IF EXISTS post_channel_message CASCADE;
+
+CREATE TABLE post_channel_message (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+	user_id BIGINT UNSIGNED,
+    channel_id BIGINT UNSIGNED,
+	channel_message_id BIGINT UNSIGNED,
+    posted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY(id, user_id, channel_id, channel_message_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (channel_id) REFERENCES channels(id) ON DELETE CASCADE,
+    FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
+	INDEX index_post_channel_message_on_posted_at (posted_at)
+) comment 'チャンネルメッセージ投稿';
+
+-- チャンネルメッセージ削除
+DROP TABLE IF EXISTS delete_channel_message CASCADE;
+
+CREATE TABLE delete_channel_message (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+	channel_message_id BIGINT UNSIGNED,
+    deleted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY(id, channel_message_id),
+    FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
+	INDEX index_delete_channel_message_on_deleted_at (deleted_at)
+) comment 'チャンネルメッセージ削除';
+
+-- チャンネルメッセージ編集
+DROP TABLE IF EXISTS edit_channel_message CASCADE;
+
+CREATE TABLE edit_channel_message (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+	channel_message_id BIGINT UNSIGNED,
+	before_edit_content VARCHAR(255) NOT NULL,
+    edited_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY(id, channel_message_id),
+    FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
+	INDEX index_edit_channel_message_on_edited_at (edited_at)
+) comment 'チャンネルメッセージ編集';
+
+-- スレッドメッセージ投稿
+DROP TABLE IF EXISTS post_thread_message CASCADE;
+
+CREATE TABLE post_thread_message (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+	user_id BIGINT UNSIGNED,
+	thread_message_id BIGINT UNSIGNED,
+    posted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY(id, user_id, thread_message_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (thread_message_id) REFERENCES thread_messages(id) ON DELETE CASCADE,
+	INDEX index_post_thread_message_on_posted_at (posted_at)
+) comment 'スレッドメッセージ投稿';
+
+-- スレッドメッセージ削除
+DROP TABLE IF EXISTS delete_thread_message CASCADE;
+
+CREATE TABLE delete_thread_message (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+	thread_message_id BIGINT UNSIGNED,
+    deleted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY(id, thread_message_id),
+    FOREIGN KEY (thread_message_id) REFERENCES thread_messages(id) ON DELETE CASCADE,
+	INDEX index_delete_thread_message_on_deleted_at (deleted_at)
+) comment 'スレッドメッセージ削除';
+
+-- スレッドメッセージ編集
+DROP TABLE IF EXISTS edit_thread_message CASCADE;
+
+CREATE TABLE edit_thread_message (
+	id BIGINT UNSIGNED AUTO_INCREMENT,
+	thread_message_id BIGINT UNSIGNED,
+	before_edit_content VARCHAR(255) NOT NULL,
+    edited_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY(id, thread_message_id),
+    FOREIGN KEY (thread_message_id) REFERENCES thread_messages(id) ON DELETE CASCADE,
+	INDEX index_edit_thread_message_on_edited_at (edited_at)
+) comment 'スレッドメッセージ編集';

--- a/I84PdeRyF2ApGF/db_modeling02/create_tables.sql
+++ b/I84PdeRyF2ApGF/db_modeling02/create_tables.sql
@@ -2,184 +2,184 @@
 DROP TABLE IF EXISTS users CASCADE;
 
 CREATE TABLE users (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-	display_name VARCHAR(255) NOT NULL,
-	first_name VARCHAR(255) NOT NULL,
-	last_name VARCHAR(255) NOT NULL,
-    email VARCHAR(255) NOT NULL UNIQUE,
-	PRIMARY KEY(id)
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  display_name VARCHAR(255) NOT NULL,
+  first_name VARCHAR(255) NOT NULL,
+  last_name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL UNIQUE,
+  PRIMARY KEY(id)
 ) comment 'ユーザー';
 
 -- ワークスペース
 DROP TABLE IF EXISTS workspaces CASCADE;
 
 CREATE TABLE workspaces (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-	name VARCHAR(255) NOT NULL,
-	PRIMARY KEY(id)
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  name VARCHAR(255) NOT NULL,
+  PRIMARY KEY(id)
 ) comment 'ワークスペース';
 
 -- チャンネル
 DROP TABLE IF EXISTS channels CASCADE;
 
 CREATE TABLE channels (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-    workspace_id BIGINT UNSIGNED NOT NULL ,
-	name VARCHAR(255) NOT NULL,
-	PRIMARY KEY(id),
-    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  workspace_id BIGINT UNSIGNED NOT NULL ,
+  name VARCHAR(255) NOT NULL,
+  PRIMARY KEY(id),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
 ) comment 'チャンネル';
 
 -- ワークスペース参加
 DROP TABLE IF EXISTS join_workspace CASCADE;
 
 CREATE TABLE join_workspace (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-    user_id BIGINT UNSIGNED NOT NULL,
-    workspace_id BIGINT UNSIGNED NOT NULL,
-	joined_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, 
-	PRIMARY KEY(id),
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  user_id BIGINT UNSIGNED NOT NULL,
+  workspace_id BIGINT UNSIGNED NOT NULL,
+  joined_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+  PRIMARY KEY(id),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
 ) comment 'ワークスペース参加';
 
 -- ワークスペース脱退
 DROP TABLE IF EXISTS leave_workspace CASCADE;
 
 CREATE TABLE leave_workspace (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-    user_id BIGINT UNSIGNED NOT NULL,
-    workspace_id BIGINT UNSIGNED NOT NULL,
-	left_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, 
-	PRIMARY KEY(id),
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  user_id BIGINT UNSIGNED NOT NULL,
+  workspace_id BIGINT UNSIGNED NOT NULL,
+  left_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+  PRIMARY KEY(id),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
 ) comment 'ワークスペース脱退';
 
 -- チャンネル参加
 DROP TABLE IF EXISTS join_channel CASCADE;
 
 CREATE TABLE join_channel (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-    user_id BIGINT UNSIGNED NOT NULL,
-    channel_id BIGINT UNSIGNED NOT NULL,
-	joined_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, 
-	PRIMARY KEY(id),
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (channel_id) REFERENCES channels(id) ON DELETE CASCADE
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  user_id BIGINT UNSIGNED NOT NULL,
+  channel_id BIGINT UNSIGNED NOT NULL,
+  joined_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+  PRIMARY KEY(id),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (channel_id) REFERENCES channels(id) ON DELETE CASCADE
 ) comment 'チャンネル参加';
 
 -- チャンネル脱退
 DROP TABLE IF EXISTS leave_channel CASCADE;
 
 CREATE TABLE leave_channel (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-    user_id BIGINT UNSIGNED NOT NULL,
-    channel_id BIGINT UNSIGNED NOT NULL,
-	left_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, 
-	PRIMARY KEY(id),
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (channel_id) REFERENCES channels(id) ON DELETE CASCADE
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  user_id BIGINT UNSIGNED NOT NULL,
+  channel_id BIGINT UNSIGNED NOT NULL,
+  left_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP, 
+  PRIMARY KEY(id),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (channel_id) REFERENCES channels(id) ON DELETE CASCADE
 ) comment 'チャンネル脱退';
 
 -- チャンネルメッセージ
 DROP TABLE IF EXISTS channel_messages CASCADE;
 
 CREATE TABLE channel_messages (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-    content VARCHAR(255) NOT NULL,
-	PRIMARY KEY(id),
-	INDEX index_channel_messages_on_content (content)
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  content VARCHAR(255) NOT NULL,
+  PRIMARY KEY(id),
+  INDEX index_channel_messages_on_content (content)
 ) comment 'チャンネルメッセージ';
 
 -- スレッドメッセージ
 DROP TABLE IF EXISTS thread_messages CASCADE;
 
 CREATE TABLE thread_messages (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-    channel_message_id BIGINT UNSIGNED NOT NULL,
-    content VARCHAR(255) NOT NULL,
-	PRIMARY KEY(id),
-    FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
-	INDEX index_thread_messages_on_content (content)
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  channel_message_id BIGINT UNSIGNED NOT NULL,
+  content VARCHAR(255) NOT NULL,
+  PRIMARY KEY(id),
+  FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
+  INDEX index_thread_messages_on_content (content)
 ) comment 'スレッドメッセージ';
 
 -- チャンネルメッセージ投稿
 DROP TABLE IF EXISTS post_channel_message CASCADE;
 
 CREATE TABLE post_channel_message (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-	user_id BIGINT UNSIGNED,
-    channel_id BIGINT UNSIGNED,
-	channel_message_id BIGINT UNSIGNED,
-    posted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	PRIMARY KEY(id, user_id, channel_id, channel_message_id),
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (channel_id) REFERENCES channels(id) ON DELETE CASCADE,
-    FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
-	INDEX index_post_channel_message_on_posted_at (posted_at)
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  user_id BIGINT UNSIGNED,
+  channel_id BIGINT UNSIGNED,
+  channel_message_id BIGINT UNSIGNED,
+  posted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY(id, user_id, channel_id, channel_message_id),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (channel_id) REFERENCES channels(id) ON DELETE CASCADE,
+  FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
+  INDEX index_post_channel_message_on_posted_at (posted_at)
 ) comment 'チャンネルメッセージ投稿';
 
 -- チャンネルメッセージ削除
 DROP TABLE IF EXISTS delete_channel_message CASCADE;
 
 CREATE TABLE delete_channel_message (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-	channel_message_id BIGINT UNSIGNED,
-    deleted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	PRIMARY KEY(id, channel_message_id),
-    FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
-	INDEX index_delete_channel_message_on_deleted_at (deleted_at)
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  channel_message_id BIGINT UNSIGNED,
+  deleted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY(id, channel_message_id),
+  FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
+  INDEX index_delete_channel_message_on_deleted_at (deleted_at)
 ) comment 'チャンネルメッセージ削除';
 
 -- チャンネルメッセージ編集
 DROP TABLE IF EXISTS edit_channel_message CASCADE;
 
 CREATE TABLE edit_channel_message (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-	channel_message_id BIGINT UNSIGNED,
-	before_edit_content VARCHAR(255) NOT NULL,
-    edited_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	PRIMARY KEY(id, channel_message_id),
-    FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
-	INDEX index_edit_channel_message_on_edited_at (edited_at)
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  channel_message_id BIGINT UNSIGNED,
+  before_edit_content VARCHAR(255) NOT NULL,
+  edited_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY(id, channel_message_id),
+  FOREIGN KEY (channel_message_id) REFERENCES channel_messages(id) ON DELETE CASCADE,
+  INDEX index_edit_channel_message_on_edited_at (edited_at)
 ) comment 'チャンネルメッセージ編集';
 
 -- スレッドメッセージ投稿
 DROP TABLE IF EXISTS post_thread_message CASCADE;
 
 CREATE TABLE post_thread_message (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-	user_id BIGINT UNSIGNED,
-	thread_message_id BIGINT UNSIGNED,
-    posted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	PRIMARY KEY(id, user_id, thread_message_id),
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-    FOREIGN KEY (thread_message_id) REFERENCES thread_messages(id) ON DELETE CASCADE,
-	INDEX index_post_thread_message_on_posted_at (posted_at)
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  user_id BIGINT UNSIGNED,
+  thread_message_id BIGINT UNSIGNED,
+  posted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY(id, user_id, thread_message_id),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (thread_message_id) REFERENCES thread_messages(id) ON DELETE CASCADE,
+  INDEX index_post_thread_message_on_posted_at (posted_at)
 ) comment 'スレッドメッセージ投稿';
 
 -- スレッドメッセージ削除
 DROP TABLE IF EXISTS delete_thread_message CASCADE;
 
 CREATE TABLE delete_thread_message (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-	thread_message_id BIGINT UNSIGNED,
-    deleted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	PRIMARY KEY(id, thread_message_id),
-    FOREIGN KEY (thread_message_id) REFERENCES thread_messages(id) ON DELETE CASCADE,
-	INDEX index_delete_thread_message_on_deleted_at (deleted_at)
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  thread_message_id BIGINT UNSIGNED,
+  deleted_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY(id, thread_message_id),
+  FOREIGN KEY (thread_message_id) REFERENCES thread_messages(id) ON DELETE CASCADE,
+  INDEX index_delete_thread_message_on_deleted_at (deleted_at)
 ) comment 'スレッドメッセージ削除';
 
 -- スレッドメッセージ編集
 DROP TABLE IF EXISTS edit_thread_message CASCADE;
 
 CREATE TABLE edit_thread_message (
-	id BIGINT UNSIGNED AUTO_INCREMENT,
-	thread_message_id BIGINT UNSIGNED,
-	before_edit_content VARCHAR(255) NOT NULL,
-    edited_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	PRIMARY KEY(id, thread_message_id),
-    FOREIGN KEY (thread_message_id) REFERENCES thread_messages(id) ON DELETE CASCADE,
-	INDEX index_edit_thread_message_on_edited_at (edited_at)
+  id BIGINT UNSIGNED AUTO_INCREMENT,
+  thread_message_id BIGINT UNSIGNED,
+  before_edit_content VARCHAR(255) NOT NULL,
+  edited_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY(id, thread_message_id),
+  FOREIGN KEY (thread_message_id) REFERENCES thread_messages(id) ON DELETE CASCADE,
+  INDEX index_edit_thread_message_on_edited_at (edited_at)
 ) comment 'スレッドメッセージ編集';

--- a/I84PdeRyF2ApGF/db_modeling02/docker-compose.yml
+++ b/I84PdeRyF2ApGF/db_modeling02/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+
+services:
+  # MySQL
+  db:
+    platform: linux/x86_64
+    image: mysql:5.7
+    container_name: mysql_modeling02
+    environment: 
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+      MYSQL_DATABASE: modeling02_database
+      MYSQL_USER: docker
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD}"
+      TZ: 'Asia/Tokyo'
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - ./docker/db/data:/var/lib/mysql
+      - ./docker/db/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./docker/db/sql:/docker-entrypoint-initdb.d
+    ports:
+      - 3306:3306

--- a/I84PdeRyF2ApGF/db_modeling02/er_diagram.md
+++ b/I84PdeRyF2ApGF/db_modeling02/er_diagram.md
@@ -14,7 +14,7 @@ erDiagram
 	users ||--o{ post_channel_messages : ""
 	channels ||--o{ post_channel_messages : ""
 	users ||--o{ post_thread_messages : ""
-	post_channel_messages ||--o{ channel_messages : ""
+	post_channel_messages ||--|| channel_messages : ""
 	channel_messages ||--o{ delete_channel_messages : ""
 	channel_messages ||--o{ edit_channel_messages : ""
 	channel_messages ||--o{ thread_messages : ""

--- a/I84PdeRyF2ApGF/db_modeling02/er_diagram.md
+++ b/I84PdeRyF2ApGF/db_modeling02/er_diagram.md
@@ -73,7 +73,6 @@ erDiagram
 	post_thread_messages{
         bigint id PK
         bigint user_id FK
-        bigint thread_message_id FK
         datetime posted_at
     }
 
@@ -103,7 +102,6 @@ erDiagram
         bigint id PK
         bigint user_id FK
 		bigint channel_id FK
-        bigint channel_message_id FK
         datetime posted_at
     }
 

--- a/I84PdeRyF2ApGF/db_modeling02/er_diagram.md
+++ b/I84PdeRyF2ApGF/db_modeling02/er_diagram.md
@@ -1,0 +1,124 @@
+```mermaid
+erDiagram
+	
+	%% リレーション
+	users ||--o{ join_workspace : ""
+	users ||--o{ leave_workspace : ""
+    channels }o--|| workspaces : ""
+	join_workspace }o--|| workspaces : ""
+	leave_workspace }o--|| workspaces : ""
+	users ||--o{ join_channel : ""
+	users ||--o{ leave_channel : ""
+	join_channel }o--|| channels : ""
+	leave_channel }o--|| channels : ""
+	users ||--o{ post_channel_messages : ""
+	channels ||--o{ post_channel_messages : ""
+	users ||--o{ post_thread_messages : ""
+	post_channel_messages ||--o{ channel_messages : ""
+	channel_messages ||--o{ delete_channel_messages : ""
+	channel_messages ||--o{ edit_channel_messages : ""
+	channel_messages ||--o{ thread_messages : ""
+	post_thread_messages ||--o{ thread_messages : ""
+	thread_messages }o--|| delete_thread_messages : ""
+	thread_messages }o--|| edit_thread_messages : ""
+
+	%% テーブル
+	join_channel{
+		bigint id PK
+		bigint user_id FK
+		bigint channel_id FK
+		datetime joined_at
+	}
+
+	leave_channel{
+		bigint id PK
+		bigint user_id FK
+		bigint channel_id Fk
+		datetime left_at
+	}
+
+	join_workspace{
+		bigint id PK
+		bigint user_id FK
+		bigint workspace_id FK
+		datetime joined_at
+	}
+
+	leave_workspace{
+		bigint id PK
+		bigint user_id FK
+		bigint workspace_id Fk
+		datetime left_at
+	}
+
+	delete_thread_messages{
+        bigint id PK
+        bigint thread_message_id FK
+        datetime deleted_at
+    }
+
+	delete_channel_messages{
+        bigint id PK
+        bigint channel_message_id FK
+        datetime deleted_at
+    }
+
+	edit_channel_messages{
+        bigint id PK
+        bidint channel_message_id FK
+		varchar before_edit_content 
+        datetime edited_at
+    }
+
+	post_thread_messages{
+        bigint id PK
+        bigint user_id FK
+        bigint thread_message_id FK
+        datetime posted_at
+    }
+
+    edit_thread_messages{
+        bigint id PK
+        bidint thread_message_id FK
+		varchar before_thread_message
+        datetime edited_at
+    }
+
+	thread_messages{
+        bigint id PK
+		bigint channel_message_id FK
+		varchar content
+	}
+
+	users{
+		bigint id PK
+		varchar display_name
+		varchar first_name
+		varchar last_name
+		varchar email 
+	}
+
+    post_channel_messages{
+        bigint id PK
+        bigint user_id FK
+		bigint channel_id FK
+        bigint channel_message_id FK
+        datetime posted_at
+    }
+
+	channel_messages{
+        bigint id PK
+		varchar content
+	}	
+	
+	channels{
+		bigint id PK
+		bigint workspace_id FK
+		varchar name
+	}
+	
+	workspaces{
+		bigint id PK
+		varcahr name
+	}
+```

--- a/I84PdeRyF2ApGF/db_modeling02/er_diagram.md
+++ b/I84PdeRyF2ApGF/db_modeling02/er_diagram.md
@@ -18,7 +18,7 @@ erDiagram
 	channel_messages ||--o{ delete_channel_messages : ""
 	channel_messages ||--o{ edit_channel_messages : ""
 	channel_messages ||--o{ thread_messages : ""
-	post_thread_messages ||--o{ thread_messages : ""
+	post_thread_messages ||--|| thread_messages : ""
 	thread_messages }o--|| delete_thread_messages : ""
 	thread_messages }o--|| edit_thread_messages : ""
 
@@ -87,6 +87,7 @@ erDiagram
 	thread_messages{
         bigint id PK
 		bigint channel_message_id FK
+		bigint post_thread_message_id FK
 		varchar content
 	}
 
@@ -108,6 +109,7 @@ erDiagram
 
 	channel_messages{
         bigint id PK
+		bigint post_channel_message_id FK
 		varchar content
 	}	
 	

--- a/I84PdeRyF2ApGF/db_modeling02/er_diagram_2.md
+++ b/I84PdeRyF2ApGF/db_modeling02/er_diagram_2.md
@@ -1,0 +1,108 @@
+``` mermaid
+erDiagram
+    %% イミュータブル考えないテーブル構造
+
+    workspaces ||--o{ workspace_channels : ""
+    users ||--o{ user_channels : ""
+    user_channels }o--|| channels : ""
+    workspace_channels }o--|| channels : ""
+    users ||--o{ channel_messages : ""
+    channels ||--o{ channel_messages : ""
+    channel_messages ||--o{ threads : ""
+    users ||--o{ user_direct_message_rooms : ""
+    user_direct_message_rooms }o--|| direct_message_rooms : ""
+    users ||--o{ direct_messages : ""
+    direct_messages }o--|| direct_message_rooms : ""
+    direct_messages ||--o{ threads : ""
+    threads ||--o{ thread_messages : ""
+
+    users{
+        bigint id PK
+        varchar display_name
+        varchar first_name
+        varchar last_name
+        varchar email
+        datetime created_at
+        datetime updated_at
+        datetime deleted_at
+    }
+
+    user_channels{
+        bigint id PK
+        bigint user_id FK
+        bigint channel_id FK
+    }
+
+    channels{
+        BIGINT id PK
+        BIGINT created_by FK
+        VARCHAR name
+        VARCHAR description
+        DATETIME created_at
+        DATETIME updated_at
+        DATETIME deleted_at
+    }
+
+    workspace_channels{
+        bigint id PK
+        bigint channel_id FK
+        bigint workspace_id FK
+    }
+
+    workspaces{
+        BIGINT id PK
+        VARCHAR name
+        BIGINT created_by
+        DATETIME created_at
+        DATETIME updated_at
+        DATETIME deleted_at
+    }
+
+    channel_messages{
+        bigint id PK
+        bigint send_user_id FK
+        bigint channel_id FK
+        varchar content
+        datetime sent_at
+        datetime updated_at
+        datetime deleted_at
+    }
+
+    threads{
+        bigint id PK
+        bigint channel_message_id FK
+        bigint direct_message_id FK
+        datetime created_at
+    }
+
+    thread_messages{
+        bigint id PK
+        bigint send_user_id FK
+        bigint thread_id FK
+        varchar content
+        datetime sent_at
+        datetime updated_at
+        datetime deleted_at
+    }
+
+    direct_message_rooms{
+        bigint id PK
+    }
+
+    user_direct_message_rooms{
+        bigint id PK
+        bigint user_id FK
+        bigint direct_message_room_id FK
+    }
+
+    direct_messages{
+        bigint id PK
+        bigint send_user_id FK
+        bigint direct_message_room_id FK
+        varchar content
+        datetime sent_at
+        datetime updated_at
+        datetime deleted_at
+    }
+
+```

--- a/I84PdeRyF2ApGF/db_modeling02/insert_sample_date.sql
+++ b/I84PdeRyF2ApGF/db_modeling02/insert_sample_date.sql
@@ -1,0 +1,123 @@
+-- ユーザー 
+INSERT INTO `users` (`id`, `display_name`, `first_name`, `last_name`, `email`)
+VALUES
+	(DEFAULT, 'Kenta', 'Kenta', 'Hirakata', 'kenta@gmail.com'),
+	(DEFAULT, 'Ichiro', 'Ichiro', 'Suzuki', 'ichiro51@gmail.com'),
+	(DEFAULT, 'Taro.Y', 'Taro', 'Yamada', 'taro@gmail.com'),
+	(DEFAULT, 'Kouji', 'Kouji', 'Yamamoto', 'kouji@gmail.com');
+
+-- ワークスペース
+INSERT INTO `workspaces` (`id`, `name`)
+VALUES
+	(DEFAULT, 'PrahaA'),
+	(DEFAULT, 'PrahaB'),
+	(DEFAULT, 'PrahaC');
+
+-- チャンネル
+INSERT INTO `channels` (`id`, `workspace_id`, `name`)
+VALUES
+	(DEFAULT, 1, 'Team-1'),
+	(DEFAULT, 1, 'Team-2'),
+	(DEFAULT, 2, 'Team-A'),
+	(DEFAULT, 2, 'Team-B');
+
+-- チャンネルメッセージ
+INSERT INTO `channel_messages` (`id`, `content`)
+VALUES
+	(DEFAULT, 'こんにちは！'),
+	(DEFAULT, 'いい天気ですね！'),
+	(DEFAULT, 'お元気ですか？'),
+	(DEFAULT, '初めまして！よろしくお願いいたします。'),
+	(DEFAULT, 'こちらこそよろしくお願いいたします。'),
+	(DEFAULT, '好きな食べ物はなんですか？'),
+	(DEFAULT, '教えません。'),
+	(DEFAULT, 'それは残念です。'),
+	(DEFAULT, 'これからよろしくおねがいします！');
+
+-- スレッドメッセージ
+INSERT INTO `thread_messages` (`id`, `channel_message_id`, `content`)
+VALUES
+	(DEFAULT, 1, '曇りですけどね。'),
+	(DEFAULT, 1, 'そうですね。ごめんなさい。'),
+	(DEFAULT, 1, '大丈夫です'),
+	(DEFAULT, 9, 'よろしくです！');
+
+-- ワークスペース参加
+INSERT INTO `join_workspace` (`id`, `user_id`, `workspace_id`, `joined_at`)
+VALUES
+	(DEFAULT, 1, 1, '2023-04-21 23:52:32'),
+	(DEFAULT, 2, 1, '2023-04-21 23:53:56'),
+	(DEFAULT, 3, 1, '2023-04-21 23:54:10'),
+	(DEFAULT, 2, 2, '2023-04-21 23:54:22'),
+	(DEFAULT, 4, 2, '2023-04-21 23:54:33'),
+	(DEFAULT, 3, 2, '2023-04-21 23:55:11'),
+	(DEFAULT, 1, 2, '2023-04-21 23:55:23'),
+	(DEFAULT, 2, 3, '2023-04-21 23:55:34'),
+	(DEFAULT, 3, 3, '2023-04-21 23:55:42'),
+	(DEFAULT, 4, 3, '2023-04-22 00:05:31');
+
+--　ワークスペース脱退
+INSERT INTO `leave_workspace` (`id`, `user_id`, `workspace_id`, `left_at`)
+VALUES
+	(DEFAULT, 1, 2, '2023-04-22 00:01:39');
+
+-- チャンネル参加
+INSERT INTO `join_channel` (`id`, `user_id`, `channel_id`, `joined_at`)
+VALUES
+	(DEFAULT, 1, 1, '2023-04-22 00:00:17'),
+	(DEFAULT, 2, 1, '2023-04-22 00:00:45'),
+	(DEFAULT, 1, 2, '2023-04-22 00:00:57'),
+	(DEFAULT, 3, 2, '2023-04-22 00:01:18'),
+	(DEFAULT, 1, 3, '2023-04-22 00:03:23'),
+	(DEFAULT, 2, 3, '2023-04-22 00:03:40'),
+	(DEFAULT, 3, 3, '2023-04-22 00:03:49'),
+	(DEFAULT, 4, 3, '2023-04-22 00:04:06'),
+	(DEFAULT, 2, 4, '2023-04-22 00:04:31'),
+	(DEFAULT, 3, 4, '2023-04-22 00:04:41');
+
+-- チャンネル脱退
+INSERT INTO `leave_channel` (`id`, `user_id`, `channel_id`, `left_at`)
+VALUES
+	(DEFAULT, 4, 3, '2023-04-22 00:06:00');
+
+-- チャンネルメッセージ投稿
+INSERT INTO `post_channel_message` (`id`, `user_id`, `channel_id`, `channel_message_id`, `posted_at`)
+VALUES
+	(DEFAULT, 1, 1, 1, '2023-04-22 00:09:08'),
+	(DEFAULT, 2, 1, 2, '2023-04-22 00:12:13'),
+	(DEFAULT, 1, 1, 3, '2023-04-22 00:12:32'),
+	(DEFAULT, 2, 3, 4, '2023-04-22 00:22:54'),
+	(DEFAULT, 3, 3, 5, '2023-04-22 00:25:43'),
+	(DEFAULT, 4, 3, 6, '2023-04-22 00:26:24'),
+	(DEFAULT, 2, 3, 7, '2023-04-22 00:26:38'),
+	(DEFAULT, 4, 3, 8, '2023-04-24 15:16:32'),
+	(DEFAULT, 1, 1, 9, '2023-04-24 17:13:44');
+
+-- チャンネルメッセージ削除
+INSERT INTO `delete_channel_message` (`id`, `channel_message_id`, `deleted_at`)
+VALUES
+	(DEFAULT, 3, '2023-04-22 09:49:47'),
+	(DEFAULT, 8, '2023-04-24 15:57:14');
+
+-- チャンネルメッセージ編集
+INSERT INTO `edit_channel_message` (`id`, `channel_message_id`, `before_edit_content`, `edited_at`)
+VALUES
+	(DEFAULT, 1, 'Hello!', '2023-04-22 09:48:45');
+
+-- スレッドメッセージ投稿
+INSERT INTO `post_thread_message` (`id`, `user_id`, `thread_message_id`, `posted_at`)
+VALUES
+	(DEFAULT, 1, 1, '2023-04-22 00:29:06'),
+	(DEFAULT, 2, 2, '2023-04-22 00:29:13'),
+	(DEFAULT, 2, 3, '2023-04-24 17:16:03'),
+	(DEFAULT, 2, 4, '2023-04-24 17:15:07');
+
+-- スレッドメッセージ削除
+INSERT INTO `delete_thread_message` (`id`, `thread_message_id`, `deleted_at`)
+VALUES
+	(DEFAULT, 3, '2023-04-24 23:07:11');
+
+-- スレッドメッセージ編集
+INSERT INTO `edit_thread_message` (`id`, `thread_message_id`, `before_edit_content`, `edited_at`)
+VALUES
+	(DEFAULT, 1, '晴れですね。', '2023-04-22 09:59:10');

--- a/I84PdeRyF2ApGF/db_modeling02/sample_dml.sql
+++ b/I84PdeRyF2ApGF/db_modeling02/sample_dml.sql
@@ -1,0 +1,134 @@
+-- 各ユーザーが現在参加しているワークスペース一覧ビュー
+CREATE VIEW current_join_workspaces_view(
+  user_id, user_displayname, workspace_id, workspace_name, joined_at)
+AS SELECT
+  u.id AS user_id,
+  u.display_name AS user_displayname,
+  j_w.workspace_id AS workspace_id,
+  w.name AS workspace_name,
+  j_w.joined_at AS joined_at
+FROM users u
+INNER JOIN join_workspace j_w ON u.id = j_w.user_id
+LEFT JOIN leave_workspace l_w ON u.id = l_W.user_id
+	  AND j_w.workspace_id = l_w.workspace_id
+INNER JOIN workspaces w ON j_w.workspace_id = w.id
+WHERE j_w.joined_at > COALESCE(l_w.left_at, 0)
+ORDER BY user_id;
+
+-- 各ユーザーが現在参加しているチャンネル一覧ビュー
+CREATE VIEW current_join_channels_view(
+  user_id, user_displayname, channel_id, channel_name, joined_at)
+AS SELECT
+   u.id AS user_id,
+   u.display_name AS user_displayname,
+   j_c.channel_id AS channel_id,
+   c.name AS channel_name,
+   j_c.joined_at AS joined_at
+FROM users u 
+INNER JOIN  join_channel j_c ON u.id = j_c.user_id
+LEFT JOIN  leave_channel l_c ON u.id = l_c.user_id
+      AND  j_c.channel_id = l_c.channel_id
+INNER JOIN channels c ON j_c.channel_id = c.id 
+WHERE j_c.joined_at > COALESCE(l_c.left_at,0)
+ORDER BY user_id;
+
+-- 削除されていないチャンネルメッセージ一覧ビュー
+CREATE VIEW displayed_channel_messages_view(channel_message_id, content, user_id, channel_id, posted_at, edited_at) AS
+SELECT
+  c_m.`id`,
+  c_m.`content`,
+  p_c_m.`user_id`,
+  p_c_m.`channel_id`,
+  p_c_m.`posted_at`,
+  e_c_m.`edited_at`
+FROM channel_messages c_m
+INNER JOIN post_channel_message p_c_m ON c_m.id = p_c_m.channel_message_id
+LEFT JOIN edit_channel_message e_c_m ON c_m.id = e_c_m.channel_message_id
+LEFT JOIN delete_channel_message d_c_m ON c_m.id = d_c_m.channel_message_id
+WHERE NOT EXISTS(
+	SELECT 'X' FROM `delete_channel_message` d_c_m
+	 WHERE d_c_m.`channel_message_id` = c_m.`id`
+	 AND d_c_m.`deleted_at` IS NOT NULL
+	 AND d_c_m.`deleted_at` >= COALESCE(e_c_m.`edited_at`, 0)
+	)
+ORDER BY `posted_at`, `channel_id`;
+
+-- 削除されていないスレッドメッセージ一覧ビュー
+CREATE VIEW displayed_thread_messages_view(thread_message_id, channel_id, channel_message_id, content, user_id, posted_at, edited_at) AS
+SELECT
+  t_m.`id`,
+  p_c_m.`channel_id`,
+  t_m.`channel_message_id`,
+  t_m.`content`,
+  p_t_m.user_id,
+  p_t_m.`posted_at`,
+  e_t_m.`edited_at`
+FROM thread_messages t_m
+INNER JOIN `post_thread_message` p_t_m ON t_m.`id` = p_t_m.`thread_message_id`
+INNER JOIN `channel_messages` c_m ON t_m.`channel_message_id` = c_m.`id`
+INNER JOIN `post_channel_message` p_c_m ON c_m.`id` = p_c_m.`channel_message_id`
+LEFT JOIN `edit_thread_message` e_t_m ON t_m.`id` = e_t_m.`thread_message_id`
+LEFT JOIN `delete_thread_message` d_t_m ON t_m.`id` = d_t_m.`thread_message_id`
+LEFT JOIN `delete_channel_message` d_c_m ON t_m.`channel_message_id` = d_c_m.`channel_message_id`
+WHERE NOT EXISTS(
+	SELECT 'X' FROM `delete_thread_message` d_t_m
+	 WHERE d_t_m.`thread_message_id` = t_m.`id`
+	 AND d_t_m.`deleted_at` IS NOT NULL
+	 AND d_t_m.`deleted_at` >= COALESCE(e_t_m.`edited_at`, 0)
+	)
+AND d_c_m.`deleted_at` IS NULL
+ORDER BY `posted_at`, `channel_message_id`;
+
+-- 「Team-1」チャンネルのメッセージやり取りを取得する
+SELECT
+  d_c_m_v.`channel_message_id` AS channel_message_id,
+  d_c_m_v.content AS content,
+  u.`display_name` AS username,
+  d_c_m_v.`posted_at` AS posted_at,
+  d_c_m_v.`edited_at` AS edited_at
+FROM displayed_channel_messages_view d_c_m_v
+INNER JOIN users u ON d_c_m_v.`user_id` = u.`id`
+WHERE channel_id = 1
+ORDER BY posted_at;
+
+-- 「よろしく」が含まれているとメッセージを横断検索
+-- ユーザーID：１のユーザーが所属しているチャンネルにあるメッセージ
+SELECT
+  messages.`channel_message_id`,
+  messages.`thread_message_id`,
+  messages.content
+FROM
+  ((SELECT
+      d_c_m.`channel_message_id`,
+      NULL AS thread_message_id,
+      d_c_m.content
+    FROM `displayed_channel_messages_view` d_c_m
+    WHERE d_c_m.`channel_id` IN (
+            SELECT channel_id
+    		  FROM `current_join_channels_view`ß
+    		  WHERE `user_id` = 1))
+    UNION ALL
+   (SELECT
+      NULL AS channel_message_id,
+	    d_t_m.`thread_message_id`,
+	    d_t_m.content
+    FROM `displayed_thread_messages_view` d_t_m
+    WHERE d_t_m.`channel_id` IN (
+            SELECT channel_id
+    		FROM `current_join_channels_view`
+    		WHERE `user_id` = 1)
+    )) messages
+WHERE content LIKE '%よろしく%';
+
+-- ユーザーID：２のユーザー所属している各チャンネル内のユーザーを取得する
+SELECT
+  channel_id,
+  channel_name,
+  user_id,
+  `user_displayname`
+FROM`current_join_channels_view` cjcv
+WHERE channel_id IN(
+	   SELECT channel_id
+	   FROM current_join_channels_view
+	   WHERE user_id = 2)
+ORDER BY channel_id;


### PR DESCRIPTION
## やったこと
- DBモデリング2の課題に対して、ER図・DDL・DMLを作成しました。
- docker-composeを作成し、MySQLを立ち上げられるようにしました。
- イミュータブルデータモデリングを参考にテーブルを設計しました。
  [参考記事]
  https://scrapbox.io/kawasima/%E3%82%A4%E3%83%9F%E3%83%A5%E3%83%BC%E3%82%BF%E3%83%96%E3%83%AB%E3%83%87%E3%83%BC%E3%82%BF%E3%83%A2%E3%83%87%E3%83%AB 
- テーブルは大きくリソースとイベントに分けており、以下の通りです。
  - リソース
    - users
    - channels
    - workspaces
    - channel_messages
    - thread_messages
  - イベント
    - join_workspace
    - leave_workspace
    - join_channel
    - leave_channel
    - post_channel_message
    - delete_channel_message
    - edit_channel_message
    - post_thread_message
    - delete_thread_message
    - edit_thread_message
- 基本的にINSERTのみでデータを管理していきますが、channel_messagesとthread_messagesに関しては、メッセージの編集処理が行われた際に、UPDATEされる想定にしております。
- 削除されていないデータや現在の状態を取得したいケースに対して、ビューを作成することで、シンプルなクエリでデータが抽出できるようにしています。
- ユースケースにを想定したクエリを3つ＋上記のビューを4つ作成しております。
  - あるチャンネルのメッセージのやり取りを取得する
  - 「よろしく」が含まれているメッセージを横断検索。(ユーザーID：１が所属しているチャンネルにあるメッセージ)
  - ユーザーID：２のユーザーが所属している各チャンネル内のユーザーを取得する。
  
## ER図
- er_diagram.mdのER図です。
   ※er_diagram2.mdというファイルもアップしていますが、メモで作成したものなのでレビューは大丈夫です。
![mermaid-diagram-2023-04-28-233804](https://user-images.githubusercontent.com/85465075/235177717-e284cb9b-7816-4826-9e98-077e85d0e49d.svg)